### PR TITLE
feat : 응모 생성 시 스케줄 등록 기능 구현

### DIFF
--- a/src/main/java/com/plus/domain/common/SchedulerTimeUtil.java
+++ b/src/main/java/com/plus/domain/common/SchedulerTimeUtil.java
@@ -4,11 +4,21 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 
+import com.plus.domain.draw.entity.Draw;
+import com.plus.domain.notification.enums.DrawNotificationType;
+
 public class SchedulerTimeUtil {
 
-	public static Instant calculateMinusHour(LocalDateTime localDateTime, int hour) {
-		LocalDateTime notificationTime = localDateTime.minusHours(hour);
+	public static Instant calculateNotificationTime(Draw draw, DrawNotificationType type) {
+		LocalDateTime baseTime = switch (type) {
+			case BEFORE_START -> draw.getStartTime();
+			case BEFORE_END -> draw.getEndTime();
+			default -> throw new IllegalArgumentException("존재하지 않는 알림 타입입니다.");
+		};
+
+		LocalDateTime notificationTime = baseTime.minusHours(type.time);
 		Duration duration = Duration.between(LocalDateTime.now(), notificationTime);
+
 		return Instant.now().plusSeconds(Math.max(0, duration.getSeconds()));
 	}
 

--- a/src/main/java/com/plus/domain/common/SchedulerTimeUtil.java
+++ b/src/main/java/com/plus/domain/common/SchedulerTimeUtil.java
@@ -1,0 +1,19 @@
+package com.plus.domain.common;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+public class SchedulerTimeUtil {
+
+	public static Instant calculateMinusHour(LocalDateTime localDateTime, int hour) {
+		LocalDateTime notificationTime = localDateTime.minusHours(hour);
+		Duration duration = Duration.between(LocalDateTime.now(), notificationTime);
+		return Instant.now().plusSeconds(Math.max(0, duration.getSeconds()));
+	}
+
+	public static Instant calculate(LocalDateTime localDateTime) {
+		Duration duration = Duration.between(LocalDateTime.now(), localDateTime);
+		return Instant.now().plusSeconds(Math.max(0, duration.getSeconds()));
+	}
+}

--- a/src/main/java/com/plus/domain/draw/entity/Draw.java
+++ b/src/main/java/com/plus/domain/draw/entity/Draw.java
@@ -12,12 +12,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Draw extends BaseTimestamped {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,4 +32,16 @@ public class Draw extends BaseTimestamped {
 	private DrawType drawType;
 	@Embedded
 	private Product product;
+
+	@Builder
+	public Draw(Long id, Integer totalWinner, LocalDateTime startTime, LocalDateTime endTime, LocalDateTime resultTime,
+		DrawType drawType, Product product) {
+		this.id = id;
+		this.totalWinner = totalWinner;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.resultTime = resultTime;
+		this.drawType = drawType;
+		this.product = product;
+	}
 }

--- a/src/main/java/com/plus/domain/draw/entity/Product.java
+++ b/src/main/java/com/plus/domain/draw/entity/Product.java
@@ -1,7 +1,9 @@
 package com.plus.domain.draw.entity;
 
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
+@Getter
 @Embeddable
 public class Product {
 	private String productName;

--- a/src/main/java/com/plus/domain/draw/entity/Product.java
+++ b/src/main/java/com/plus/domain/draw/entity/Product.java
@@ -1,12 +1,22 @@
 package com.plus.domain.draw.entity;
 
 import jakarta.persistence.Embeddable;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
+@NoArgsConstructor
 public class Product {
 	private String productName;
 	private String productDescription;
 	private String productImage;
+
+	@Builder
+	public Product(String productName, String productDescription, String productImage) {
+		this.productName = productName;
+		this.productDescription = productDescription;
+		this.productImage = productImage;
+	}
 }

--- a/src/main/java/com/plus/domain/notification/config/SchedulerConfig.java
+++ b/src/main/java/com/plus/domain/notification/config/SchedulerConfig.java
@@ -1,0 +1,18 @@
+package com.plus.domain.notification.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+
+	@Bean
+	public ThreadPoolTaskScheduler taskScheduler() {
+		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+		taskScheduler.setPoolSize(100);
+		taskScheduler.setThreadNamePrefix("TaskScheduler - ");
+		taskScheduler.initialize();
+		return taskScheduler;
+	}
+}

--- a/src/main/java/com/plus/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/plus/domain/notification/controller/NotificationController.java
@@ -5,13 +5,11 @@ import java.io.IOException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import com.plus.domain.draw.entity.Draw;
 import com.plus.domain.notification.service.NotificationService;
 
 import lombok.RequiredArgsConstructor;
@@ -28,10 +26,5 @@ public class NotificationController {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(notificationService.connect(userId));
-	}
-
-	@PostMapping
-	public void test() {
-		notificationService.addTask(Draw.builder().build());
 	}
 }

--- a/src/main/java/com/plus/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/plus/domain/notification/controller/NotificationController.java
@@ -5,11 +5,13 @@ import java.io.IOException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.plus.domain.draw.entity.Draw;
 import com.plus.domain.notification.service.NotificationService;
 
 import lombok.RequiredArgsConstructor;
@@ -26,5 +28,10 @@ public class NotificationController {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(notificationService.connect(userId));
+	}
+
+	@PostMapping
+	public void addTaskTest() {
+		notificationService.addTask(Draw.builder().build());
 	}
 }

--- a/src/main/java/com/plus/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/plus/domain/notification/controller/NotificationController.java
@@ -31,7 +31,7 @@ public class NotificationController {
 	}
 
 	@PostMapping
-	public void addTaskTest() {
+	public void test() {
 		notificationService.addTask(Draw.builder().build());
 	}
 }

--- a/src/main/java/com/plus/domain/notification/entity/Notification.java
+++ b/src/main/java/com/plus/domain/notification/entity/Notification.java
@@ -1,0 +1,59 @@
+package com.plus.domain.notification.entity;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import com.plus.domain.draw.entity.Draw;
+import com.plus.domain.notification.enums.DrawNotificationType;
+import com.plus.domain.notification.enums.NotificationStatus;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private Long drawId;
+	private LocalDateTime notificationTime;
+	@Enumerated(EnumType.STRING)
+	private NotificationStatus status;
+	@Enumerated(EnumType.STRING)
+	private DrawNotificationType type;
+
+	@Builder
+	public Notification(Long id, Long drawId, LocalDateTime notificationTime, NotificationStatus status,
+		DrawNotificationType type) {
+		this.id = id;
+		this.drawId = drawId;
+		this.notificationTime = notificationTime;
+		this.status = status;
+		this.type = type;
+	}
+
+	public static Notification createWithDraw(Draw draw, DrawNotificationType type, Instant notificationTime) {
+		return Notification.builder()
+			.drawId(draw.getId())
+			.status(NotificationStatus.PENDING)
+			.notificationTime(LocalDateTime.ofInstant(notificationTime, ZoneId.of("Asia/Seoul")))
+			.type(type)
+			.build();
+	}
+
+	public void complete() {
+		this.status = NotificationStatus.COMPLETE;
+	}
+}

--- a/src/main/java/com/plus/domain/notification/entity/SseEmitters.java
+++ b/src/main/java/com/plus/domain/notification/entity/SseEmitters.java
@@ -1,6 +1,7 @@
 package com.plus.domain.notification.entity;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -30,6 +31,20 @@ public class SseEmitters {
 			throw new IOException(e);
 		}
 		return emitter;
+	}
+
+	public void send(List<Long> ids, String sendNotificationBeforeDrawStart) {
+		emitters.forEach((id, emitter) -> {
+			if (ids.contains(id)) {
+				try {
+					emitter.send(SseEmitter.event()
+						.name("notification")
+						.data(sendNotificationBeforeDrawStart));
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		});
 	}
 
 	private void setEmitterConfig(Long userId) {

--- a/src/main/java/com/plus/domain/notification/enums/DrawNotificationType.java
+++ b/src/main/java/com/plus/domain/notification/enums/DrawNotificationType.java
@@ -1,0 +1,14 @@
+package com.plus.domain.notification.enums;
+
+public enum DrawNotificationType {
+	BEFORE_START(1, " 응모 시작 한시간 전 입니다."),
+	BEFORE_END(1, " 응모 종료 한시간 전 입니다.");
+
+	public final Integer time;
+	public final String message;
+
+	DrawNotificationType(Integer time, String message) {
+		this.time = time;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/plus/domain/notification/enums/NotificationStatus.java
+++ b/src/main/java/com/plus/domain/notification/enums/NotificationStatus.java
@@ -1,0 +1,5 @@
+package com.plus.domain.notification.enums;
+
+public enum NotificationStatus {
+	PENDING, COMPLETE
+}

--- a/src/main/java/com/plus/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/plus/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.plus.domain.notification.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.plus.domain.notification.entity.Notification;
+import com.plus.domain.notification.enums.DrawNotificationType;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+	Optional<Notification> findByDrawIdAndType(Long id, DrawNotificationType type);
+}

--- a/src/main/java/com/plus/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/plus/domain/notification/service/NotificationService.java
@@ -1,21 +1,73 @@
 package com.plus.domain.notification.service;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
 
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.plus.domain.common.SchedulerTimeUtil;
+import com.plus.domain.draw.entity.Draw;
+import com.plus.domain.draw.entity.Product;
 import com.plus.domain.notification.entity.SseEmitters;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j(topic = "Notification Service Logger")
 @RequiredArgsConstructor
 public class NotificationService {
 
 	private final SseEmitters emitters;
+	private final TaskScheduler taskScheduler;
+	private static final Integer ONE_HOUR = 1;
 
 	public SseEmitter connect(Long userId) throws IOException {
 		return emitters.add(userId);
+	}
+
+	@Transactional
+	public void addTask(Draw draw) {
+		Product product = draw.getProduct();
+		Instant beforeStartNoticeTime = SchedulerTimeUtil.calculateMinusHour(draw.getStartTime(), ONE_HOUR);
+		Instant beforeEndNoticeTime = SchedulerTimeUtil.calculateMinusHour(draw.getEndTime(), ONE_HOUR);
+		Instant drawTime = SchedulerTimeUtil.calculate(draw.getResultTime());
+		taskScheduler.schedule(() -> sendNotificationBeforeDrawStart(product), beforeStartNoticeTime);
+		taskScheduler.schedule(() -> sendNotificationBeforeDrawEnd(product), beforeEndNoticeTime);
+		taskScheduler.schedule(() -> sendNotificationToWinner(product), drawTime);
+	}
+
+	public void sendNotificationBeforeDrawStart(Product product) {
+		/*
+		TODO: 응모 시작 한시간 전 로직
+		List<Long> ids = List.of() => 제거예정
+		List<Long> ids = favoriteDrawRepository.findByDrawId(drawId).stream()
+			.map(favoriteDraw -> favoriteDraw.getUserId())
+			.toList();
+		*/
+		List<Long> ids = List.of(1L, 2L);
+		emitters.send(ids, product.getProductName() + "의 응모 시작 한시간 전 입니다.");
+	}
+
+	public void sendNotificationBeforeDrawEnd(Product product) {
+		/*
+		TODO: 응모 종료 한시간 전 로직
+		List<Long> ids = List.of() => 제거예정
+		List<Long> ids = favoriteDrawRepository.findByDrawId(drawId).stream()
+			.map(favoriteDraw -> favoriteDraw.getUserId())
+			.toList();
+		*/
+		List<Long> ids = List.of(1L, 2L);
+		emitters.send(ids, product.getProductName() + "의 응모 종료 한시간 전 입니다.");
+	}
+
+	public void sendNotificationToWinner(Product product) {
+		// TODO: 당첨자 알림
+		List<Long> ids = List.of(3L);
+		emitters.send(ids, product.getProductName() + "에 당첨되셨습니다!");
 	}
 }

--- a/src/main/java/com/plus/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/plus/domain/notification/service/NotificationService.java
@@ -2,7 +2,6 @@ package com.plus.domain.notification.service;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.scheduling.TaskScheduler;
@@ -12,7 +11,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.plus.domain.common.SchedulerTimeUtil;
 import com.plus.domain.draw.entity.Draw;
-import com.plus.domain.draw.entity.Product;
 import com.plus.domain.notification.entity.Notification;
 import com.plus.domain.notification.entity.SseEmitters;
 import com.plus.domain.notification.enums.DrawNotificationType;
@@ -29,24 +27,13 @@ public class NotificationService {
 	private final SseEmitters emitters;
 	private final TaskScheduler taskScheduler;
 	private final NotificationRepository notificationRepository;
-	private static final Integer ONE_HOUR = 1;
 
 	public SseEmitter connect(Long userId) throws IOException {
 		return emitters.add(userId);
 	}
 
 	@Transactional
-	public void addTask(Draw draw1) {
-		Draw draw = Draw.builder()
-			.id(1L)
-			.startTime(LocalDateTime.now().plusSeconds(3610))
-			.endTime(LocalDateTime.now().plusSeconds(3620))
-			.product(Product.builder()
-				.productName("애플워치")
-				.productImage("image")
-				.productDescription("desc")
-				.build())
-			.build();
+	public void addTask(Draw draw) {
 		for (DrawNotificationType type : DrawNotificationType.values()) {
 			try {
 				Instant notificationTime = SchedulerTimeUtil.calculateNotificationTime(draw, type);
@@ -66,7 +53,8 @@ public class NotificationService {
 			Notification notification = notificationRepository.findByDrawIdAndType(draw.getId(), type)
 				.orElseThrow(() -> new IllegalStateException("존재하지 않는 응모입니다."));
 			String productName = draw.getProduct().getProductName();
-			List<Long> ids = List.of(1L, 2L); // TODO: 실제 repository에서 해당 응모를 관심 추천 한 userIds 조회 필요
+			// TODO: 실제 repository에서 해당 응모를 관심 추천 한 userIds 조회 필요
+			List<Long> ids = List.of(1L, 2L);
 			emitters.send(ids, productName + type.message);
 			notification.complete();
 			notificationRepository.save(notification);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,6 +11,17 @@ CREATE TABLE IF NOT EXISTS user
     PRIMARY KEY (id)
 ) ENGINE = InnoDB;
 
+CREATE TABLE IF NOT EXISTS notification
+(
+    id                BIGINT NOT NULL AUTO_INCREMENT,
+    notification_time DATETIME(6),
+    draw_id           BIGINT,
+    status            ENUM ('PENDING', 'COMPLETE'),
+    type              ENUM ('BEFORE_START', 'BEFORE_END'),
+    PRIMARY KEY (id),
+    FOREIGN KEY (draw_id) REFERENCES draw (id)
+) ENGINE = InnoDB;
+
 CREATE TABLE IF NOT EXISTS draw
 (
     id                  BIGINT NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## 개요
- 스케줄에 등록해야하는 알림들은 DrawNotificationType enum으로 구분하여 반복문을 통해 등록하도록 구현.
- 등록 시 PENDING으로 저장되며, 알림이 보내진 후에는 COMPLETE로 업데이트 됨.
- 응모가 생성 될 때 addTask() 함께 호출 하여 생성과 동시에 스케줄 등록이 필요함.

Resolves: #13 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제