### PR TITLE
fix : notification 테이블 생성 에러 수정

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,17 +11,6 @@ CREATE TABLE IF NOT EXISTS user
     PRIMARY KEY (id)
 ) ENGINE = InnoDB;
 
-CREATE TABLE IF NOT EXISTS notification
-(
-    id                BIGINT NOT NULL AUTO_INCREMENT,
-    notification_time DATETIME(6),
-    draw_id           BIGINT,
-    status            ENUM ('PENDING', 'COMPLETE'),
-    type              ENUM ('BEFORE_START', 'BEFORE_END'),
-    PRIMARY KEY (id),
-    FOREIGN KEY (draw_id) REFERENCES draw (id)
-) ENGINE = InnoDB;
-
 CREATE TABLE IF NOT EXISTS draw
 (
     id                  BIGINT NOT NULL AUTO_INCREMENT,
@@ -36,6 +25,18 @@ CREATE TABLE IF NOT EXISTS draw
     start_time          DATETIME(6),
     total_winner        INT,
     PRIMARY KEY (id)
+) ENGINE = InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS notification
+(
+    id                BIGINT NOT NULL AUTO_INCREMENT,
+    notification_time DATETIME(6),
+    draw_id           BIGINT,
+    status            ENUM ('PENDING', 'COMPLETE'),
+    type              ENUM ('BEFORE_START', 'BEFORE_END'),
+    PRIMARY KEY (id),
+    FOREIGN KEY (draw_id) REFERENCES draw (id)
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS review


### PR DESCRIPTION
## 개요
draw 테이블 보다 notification 테이블 생성이 먼저 실생돼서 에러 발생.
shema.sql 파일에서 두 테이블의 생성문 순서 바꿔줌.

Resolves: #40 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제